### PR TITLE
release hardening: auth security, readiness, and web regression e2e

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+- What changed:
+- Why:
+
+## Validation
+- [ ] `apps/api`: `npm test`
+- [ ] Smoke E2E: `powershell -ExecutionPolicy Bypass -File .\scripts\smoke-e2e.ps1`
+- [ ] Web regression E2E: `cd e2e && npm test`
+- [ ] CI checks are green (`api-tests`, `smoke-e2e`, `web-regression-e2e`)
+
+## Release Safety
+- [ ] `NODE_ENV=production` configured for production deploy
+- [ ] Strong `JWT_SECRET` configured for production deploy
+- [ ] `CORS_ORIGINS` explicitly configured for production deploy
+- [ ] `/health` and `/ready` verified in target environment
+- [ ] Rollback plan prepared (link or command)
+
+## Notes
+- Risks:
+- Rollback:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,47 @@ jobs:
       - name: Stop services
         if: always()
         run: docker compose down -v
+
+  web-regression-e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: e2e/package.json
+
+      - name: Install E2E dependencies
+        run: npm install
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Build and start services
+        working-directory: .
+        run: docker compose up --build -d
+
+      - name: Run web regression E2E
+        run: npm test
+
+      - name: Dump compose status
+        if: always()
+        working-directory: .
+        run: docker compose ps
+
+      - name: Dump API logs on failure
+        if: failure()
+        working-directory: .
+        run: docker compose logs api
+
+      - name: Stop services
+        if: always()
+        working-directory: .
+        run: docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 apps/api/dist/
 .env
 .DS_Store
+e2e/test-results/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-﻿.PHONY: up down reset logs smoke
+.PHONY: up down reset logs smoke api-test web-e2e ci-local
 
 up:
 	docker compose up --build
@@ -14,3 +14,11 @@ logs:
 
 smoke:
 	powershell -ExecutionPolicy Bypass -File .\scripts\smoke-e2e.ps1
+
+api-test:
+	cd apps/api && npm test
+
+web-e2e:
+	cd e2e && npm test
+
+ci-local: api-test smoke web-e2e

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ docker compose up --build
    ```bash
    cp apps/api/.env.example apps/api/.env
    ```
+   Для production обязательно задайте сильный `JWT_SECRET` и список `CORS_ORIGINS`.
 2. Запустить проект:
    ```bash
    docker compose up --build

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ docker compose up --build
 powershell -ExecutionPolicy Bypass -File .\scripts\smoke-e2e.ps1
 ```
 
+## Web Regression E2E (Playwright)
+1. Поднимите сервисы:
+   ```bash
+   docker compose up --build -d
+   ```
+2. Установите зависимости тестов:
+   ```bash
+   cd e2e
+   npm install
+   npx playwright install chromium
+   ```
+3. Запустите тесты:
+   ```bash
+   npm test
+   ```
+
 ## API endpoints
 - `POST /api/auth/register`
 - `POST /api/auth/login`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ MVP now includes:
 docker compose up --build
 ```
 
+## Useful commands
+- `make api-test` - run API tests
+- `make smoke` - run API/web smoke checks
+- `make web-e2e` - run Playwright web regression tests
+- `make ci-local` - run all checks required before merge
+
 ## Как проверить MVP локально
 
 1. Скопировать переменные окружения API:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ docker compose up --build
    ```bash
    docker compose up --build
    ```
-3. Дождаться готовности сервисов и проверить health endpoint:
+3. Дождаться готовности сервисов и проверить health/readiness endpoints:
    ```bash
    curl http://localhost:4000/health
+   curl http://localhost:4000/ready
    ```
-   Ожидаемый ответ: `{"status":"ok"}`.
+   Ожидаемые ответы: `{"status":"ok"}` и `{"status":"ready"}`.
 4. Открыть UI для ручной проверки: `http://localhost:8080`.
 5. Пройти базовый сценарий в UI:
    - Register
@@ -40,6 +41,7 @@ docker compose up --build
 ## URLs
 - Web UI: http://localhost:8080
 - API health: http://localhost:4000/health
+- API readiness: http://localhost:4000/ready
 
 ## Smoke E2E
 Запуск после `docker compose up --build`:

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,6 @@
 ﻿PORT=4000
 JWT_SECRET=change-me
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/sobriety_track
+NODE_ENV=development
+# Comma-separated origins for production, e.g. https://app.example.com,https://admin.example.com
+CORS_ORIGINS=

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -6,7 +6,9 @@ dotenv.config();
 const envSchema = z.object({
   PORT: z.coerce.number().default(4000),
   JWT_SECRET: z.string().min(8),
-  DATABASE_URL: z.string().min(1)
+  DATABASE_URL: z.string().min(1),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  CORS_ORIGINS: z.string().optional()
 });
 
 export const env = envSchema.parse(process.env);

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import fastifyJwt from '@fastify/jwt';
+import { authRoutes } from './auth.js';
+import { pool } from '../db/pool.js';
+
+async function buildApp() {
+  const app = Fastify();
+  app.register(fastifyJwt, { secret: process.env.JWT_SECRET ?? 'test-secret-123' });
+  app.register(authRoutes, { prefix: '/api' });
+  await app.ready();
+  return app;
+}
+
+test('POST /api/auth/login rate-limits after 10 attempts per IP', async () => {
+  const originalQuery = pool.query;
+  (pool as any).query = async () => ({ rows: [], rowCount: 0 });
+
+  const app = await buildApp();
+  const payload = { login: 'demo-user', password: 'StrongPass123!' };
+
+  for (let i = 0; i < 10; i += 1) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload,
+      remoteAddress: '10.10.0.1'
+    });
+    assert.equal(res.statusCode, 401);
+  }
+
+  const limited = await app.inject({
+    method: 'POST',
+    url: '/api/auth/login',
+    payload,
+    remoteAddress: '10.10.0.1'
+  });
+  assert.equal(limited.statusCode, 429);
+  assert.equal(limited.json().error, 'Too many requests. Please try again later.');
+  assert.ok(Number(limited.headers['retry-after']) >= 1);
+
+  await app.close();
+  (pool as any).query = originalQuery;
+});
+
+test('POST /api/auth/register rate-limits after 5 attempts per IP', async () => {
+  const app = await buildApp();
+
+  for (let i = 0; i < 5; i += 1) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/register',
+      payload: {},
+      remoteAddress: '10.10.0.2'
+    });
+    assert.equal(res.statusCode, 400);
+  }
+
+  const limited = await app.inject({
+    method: 'POST',
+    url: '/api/auth/register',
+    payload: {},
+    remoteAddress: '10.10.0.2'
+  });
+  assert.equal(limited.statusCode, 429);
+  assert.equal(limited.json().error, 'Too many requests. Please try again later.');
+  assert.ok(Number(limited.headers['retry-after']) >= 1);
+
+  await app.close();
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,5 +1,5 @@
 ﻿import { createHash, randomBytes } from 'node:crypto';
-import type { FastifyPluginAsync } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import { pool } from '../db/pool.js';
 import { hashPassword, verifyPassword } from '../utils/hash.js';
@@ -26,9 +26,44 @@ const resetPasswordSchema = z.object({
 });
 
 const hashResetToken = (token: string) => createHash('sha256').update(token).digest('hex');
+const rateLimitWindowMs = 15 * 60 * 1000;
+const authRateLimits = {
+  register: 5,
+  login: 10,
+  forgotPassword: 5,
+  resetPassword: 10
+} as const;
+const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
+
+function applyAuthRateLimit(
+  reply: FastifyReply,
+  key: string,
+  maxRequests: number
+) {
+  const now = Date.now();
+  const record = rateLimitStore.get(key);
+  if (!record || record.resetAt <= now) {
+    rateLimitStore.set(key, { count: 1, resetAt: now + rateLimitWindowMs });
+    return false;
+  }
+
+  if (record.count >= maxRequests) {
+    const retryAfter = Math.max(1, Math.ceil((record.resetAt - now) / 1000));
+    reply.header('Retry-After', String(retryAfter));
+    reply.status(429).send({ error: 'Too many requests. Please try again later.' });
+    return true;
+  }
+
+  record.count += 1;
+  rateLimitStore.set(key, record);
+  return false;
+}
 
 export const authRoutes: FastifyPluginAsync = async (app) => {
   app.post('/auth/register', async (request, reply) => {
+    if (applyAuthRateLimit(reply, `register:${request.ip}`, authRateLimits.register)) {
+      return;
+    }
     const parsed = registerSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid payload', details: parsed.error.flatten() });
@@ -57,6 +92,9 @@ export const authRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post('/auth/login', async (request, reply) => {
+    if (applyAuthRateLimit(reply, `login:${request.ip}`, authRateLimits.login)) {
+      return;
+    }
     const parsed = loginSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid payload', details: parsed.error.flatten() });
@@ -81,6 +119,9 @@ export const authRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post('/auth/forgot-password', async (request, reply) => {
+    if (applyAuthRateLimit(reply, `forgot:${request.ip}`, authRateLimits.forgotPassword)) {
+      return;
+    }
     const parsed = forgotPasswordSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid payload', details: parsed.error.flatten() });
@@ -111,6 +152,9 @@ export const authRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post('/auth/reset-password', async (request, reply) => {
+    if (applyAuthRateLimit(reply, `reset:${request.ip}`, authRateLimits.resetPassword)) {
+      return;
+    }
     const parsed = resetPasswordSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: 'Invalid payload', details: parsed.error.flatten() });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,9 +9,33 @@ import { goalsRoutes } from './routes/goals.js';
 import { onboardingRoutes } from './routes/onboarding.js';
 import { profileRoutes } from './routes/profile.js';
 
+const insecureProductionSecrets = new Set(['change-me', 'change-me-super-secret', 'secret', 'password', '12345678']);
+if (env.NODE_ENV === 'production' && insecureProductionSecrets.has(env.JWT_SECRET)) {
+  throw new Error('Unsafe JWT_SECRET for production environment');
+}
+
 const app = Fastify({ logger: true });
 
-app.register(cors, { origin: true });
+const allowedOrigins = new Set(
+  (env.CORS_ORIGINS ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+);
+
+app.register(cors, {
+  origin: (origin, cb) => {
+    if (!origin) {
+      cb(null, true);
+      return;
+    }
+    if (allowedOrigins.size === 0) {
+      cb(null, env.NODE_ENV !== 'production');
+      return;
+    }
+    cb(null, allowedOrigins.has(origin));
+  }
+});
 app.register(fastifyJwt, { secret: env.JWT_SECRET });
 
 app.decorate('authenticate', async function (request: FastifyRequest, reply: FastifyReply) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,7 @@ import fastifyJwt from '@fastify/jwt';
 import cors from '@fastify/cors';
 import { env } from './config/env.js';
 import { runMigrations } from './db/migrate.js';
+import { pool } from './db/pool.js';
 import { authRoutes } from './routes/auth.js';
 import { entriesRoutes } from './routes/entries.js';
 import { goalsRoutes } from './routes/goals.js';
@@ -47,6 +48,15 @@ app.decorate('authenticate', async function (request: FastifyRequest, reply: Fas
 });
 
 app.get('/health', async () => ({ status: 'ok' }));
+app.get('/ready', async (_request, reply) => {
+  try {
+    await pool.query('SELECT 1');
+    return { status: 'ready' };
+  } catch (err) {
+    app.log.error({ err }, 'Readiness check failed');
+    return reply.status(503).send({ status: 'not_ready' });
+  }
+});
 app.register(authRoutes, { prefix: '/api' });
 app.register(entriesRoutes, { prefix: '/api' });
 app.register(goalsRoutes, { prefix: '/api' });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,15 @@
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/sobriety_track
     ports:
       - "4000:4000"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://localhost:4000/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -3,6 +3,7 @@
 ## 1. Build and Tests
 - `apps/api`: `npm ci`, `npm run typecheck`, `npm test`
 - Full smoke: `powershell -ExecutionPolicy Bypass -File .\scripts\smoke-e2e.ps1`
+- Web regression: `cd e2e && npm install && npx playwright install chromium && npm test`
 - Docker health: `docker compose ps` (all services `Up`, `postgres` and `api` healthy)
 
 ## 2. Security Baseline

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,27 @@
+# Release Checklist
+
+## 1. Build and Tests
+- `apps/api`: `npm ci`, `npm run typecheck`, `npm test`
+- Full smoke: `powershell -ExecutionPolicy Bypass -File .\scripts\smoke-e2e.ps1`
+- Docker health: `docker compose ps` (all services `Up`, `postgres` and `api` healthy)
+
+## 2. Security Baseline
+- `JWT_SECRET` is strong and unique for environment
+- `NODE_ENV=production` in production deployments
+- `CORS_ORIGINS` explicitly configured for production
+- Auth rate limits verified (`/api/auth/register`, `/api/auth/login`, `/api/auth/forgot-password`, `/api/auth/reset-password`)
+
+## 3. Runtime Readiness
+- `GET /health` returns `{"status":"ok"}`
+- `GET /ready` returns `{"status":"ready"}`
+- No sustained `5xx` errors in API logs
+
+## 4. Data and Rollback
+- Database backup confirmed before deploy
+- Rollback command/script prepared and tested
+- Migration changes reviewed for backward compatibility
+
+## 5. Post-Deploy Validation
+- Register -> Login -> Onboarding -> Goals -> Entry flow works from Web UI
+- Profile page loads and metrics are visible
+- Auth failures return expected errors (`401` or `429`)

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "sobriety-track-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sobriety-track-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sobriety-track-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.2"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000
+  },
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry'
+  },
+  reporter: [['list']]
+});

--- a/e2e/tests/auth-onboarding-regression.spec.ts
+++ b/e2e/tests/auth-onboarding-regression.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test('failed login keeps user on auth screen and does not open onboarding', async ({ page }) => {
+  await page.addInitScript(() => localStorage.clear());
+  await page.route('**/api/auth/login', async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Invalid credentials' })
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.locator('#authShell')).toBeVisible();
+
+  await page.fill('#login', 'demo_user');
+  await page.fill('#password', 'wrong-pass-123');
+  await page.locator('#loginForm button[type="submit"]').click();
+
+  await expect(page.locator('#authError')).toBeVisible();
+  await page.waitForTimeout(16_000);
+  await expect(page.locator('#authShell')).toBeVisible();
+  await expect(page.locator('#onboardingShell')).toBeHidden();
+});
+
+test('stale token and onboarding API failure returns to auth screen', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('token', 'stale-token'));
+
+  await page.route('**/api/goals', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ activeGoal: null, progress: null })
+    });
+  });
+
+  await page.route('**/api/onboarding', async (route) => {
+    const req = route.request();
+    if (req.method() === 'GET') {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Internal server error' })
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.goto('/');
+  await expect(page.locator('#authShell')).toBeVisible();
+  await expect(page.locator('#onboardingShell')).toBeHidden();
+});

--- a/scripts/smoke-e2e.ps1
+++ b/scripts/smoke-e2e.ps1
@@ -23,6 +23,12 @@ if ($health.status -ne "ok") {
   throw "Health check failed"
 }
 
+Step "Readiness"
+$ready = Invoke-RestMethod -Method GET -Uri "$ApiBase/ready"
+if ($ready.status -ne "ready") {
+  throw "Readiness check failed"
+}
+
 Step "Auth register/login"
 $registerBody = @{ login = $login; email = $email; displayName = "Smoke User"; password = $password } | ConvertTo-Json
 [void](Invoke-RestMethod -Method POST -Uri "$api/auth/register" -ContentType "application/json" -Body $registerBody)

--- a/scripts/smoke-e2e.ps1
+++ b/scripts/smoke-e2e.ps1
@@ -35,6 +35,28 @@ if (-not $token) {
 }
 $headers = @{ Authorization = "Bearer $token" }
 
+Step "Auth negative checks"
+$badLoginBody = @{ login = $login; password = "WrongPass123!" } | ConvertTo-Json
+try {
+  [void](Invoke-RestMethod -Method POST -Uri "$api/auth/login" -ContentType "application/json" -Body $badLoginBody)
+  throw "Expected 401 for invalid credentials"
+} catch {
+  $statusCode = $_.Exception.Response.StatusCode.value__
+  if ($statusCode -ne 401) {
+    throw "Expected 401 for invalid credentials, got $statusCode"
+  }
+}
+
+try {
+  [void](Invoke-RestMethod -Method POST -Uri "$api/onboarding" -ContentType "application/json" -Body (@{ startMode = "now"; goalDays = 30 } | ConvertTo-Json))
+  throw "Expected 401 for onboarding without token"
+} catch {
+  $statusCode = $_.Exception.Response.StatusCode.value__
+  if ($statusCode -ne 401) {
+    throw "Expected 401 for onboarding without token, got $statusCode"
+  }
+}
+
 Step "Onboarding"
 $onboardingBody = @{ startMode = "now"; goalDays = 30 } | ConvertTo-Json
 $onboardingSave = Invoke-RestMethod -Method POST -Uri "$api/onboarding" -Headers $headers -ContentType "application/json" -Body $onboardingBody


### PR DESCRIPTION
## Summary\n- add auth rate limits on register/login/forgot/reset routes\n- add production security guards (NODE_ENV, CORS_ORIGINS, strong JWT_SECRET check)\n- add /ready endpoint and api container healthcheck\n- extend smoke e2e with negative auth checks\n- add Playwright web regression tests for auth/onboarding flows\n- add release checklist, PR template, and local CI make targets\n\n## Validation\n- pps/api: 
pm test\n- smoke: powershell -ExecutionPolicy Bypass -File .\\scripts\\smoke-e2e.ps1\n- web e2e: cd e2e && npm test\n\n## Notes\n- branch: eat/release-hardening-main\n- all local checks green before PR creation